### PR TITLE
magFAST - Dummy out previous year total

### DIFF
--- a/graphics/elements/gdq-omnibar/gdq-omnibar.js
+++ b/graphics/elements/gdq-omnibar/gdq-omnibar.js
@@ -1,7 +1,7 @@
 (function () {
 	'use strict';
 
-	const MMAT6_TOTAL = 7097.00;
+	const MMAT6_TOTAL = 70979999999999999.00;
 	window.MMAT6_TOTAL = MMAT6_TOTAL;
 
 	const currentBids = nodecg.Replicant('currentBids');


### PR DESCRIPTION
Since this is the first magFAST, I don't want to cite a different event's total as the last year. Set to high value to dummy it out.